### PR TITLE
Arbitrary nesting

### DIFF
--- a/src/validators/filenameIdentify.test.ts
+++ b/src/validators/filenameIdentify.test.ts
@@ -23,6 +23,7 @@ const node = {
 const recurseNode = {
   recurse: {
     baseDir: "data",
+    arbitraryNesting: true,
     extensions: [".csv"],
     suffix: "data"
   },
@@ -50,6 +51,18 @@ Deno.test('test _findRuleMatches', async (t) => {
       context.baseDir = 'data'
       _findRuleMatches(recurseNode, schemaPath, context)
       assertEquals(context.filenameRules[0], `${schemaPath}.recurse`)
+    },
+  )
+  await t.step(
+    'recurse failure without arbitraryNesting',
+     () => {
+      const fileName = 'data/raw_data/study-bfi_data.csv'
+      const file = new psychDSFileDeno(PATH, fileName, ignore)
+      const context = new psychDSContext(fileTree, file, issues)
+      context.baseDir = 'data'
+      recurseNode.recurse.arbitraryNesting = false
+      _findRuleMatches(recurseNode, schemaPath, context)
+      assertEquals(context.filenameRules, [])
     },
   )
 })

--- a/src/validators/filenameIdentify.ts
+++ b/src/validators/filenameIdentify.ts
@@ -108,8 +108,6 @@ export function _findRuleMatches(node, path, context) {
     ('extensions' in node && node.extensions.includes(context.extension)) &&
     ('suffix' in node && context.suffix === node.suffix))
   ) {
-    console.log(('extensions' in node && node.extensions.includes(context.extension)))
-    console.log(('suffix' in node && context.suffix === node.suffix))
     context.filenameRules.push(path)
     return
   }
@@ -120,7 +118,6 @@ export function _findRuleMatches(node, path, context) {
       if(
         typeof node[key] === 'object'
       ){
-        console.log('recurse')
         _findRuleMatches(node[key], `${path}.${key}`, context)
       }
     })

--- a/src/validators/filenameIdentify.ts
+++ b/src/validators/filenameIdentify.ts
@@ -103,10 +103,13 @@ export function _findRuleMatches(node, path, context) {
   if (
     ('path' in node && context.file.name.endsWith(node.path)) ||
     ('stem' in node && context.file.name.startsWith(node.stem)) ||
-    (('baseDir' in node && context.baseDir === node.baseDir) &&
+    ((('baseDir' in node && 'arbitraryNesting' in node && node.arbitraryNesting && context.baseDir === node.baseDir) ||
+    ('baseDir' in node && 'arbitraryNesting' in node && !node.arbitraryNesting && context.path === `/${node.baseDir}/${context.file.name}`)) &&
     ('extensions' in node && node.extensions.includes(context.extension)) &&
     ('suffix' in node && context.suffix === node.suffix))
   ) {
+    console.log(('extensions' in node && node.extensions.includes(context.extension)))
+    console.log(('suffix' in node && context.suffix === node.suffix))
     context.filenameRules.push(path)
     return
   }
@@ -117,6 +120,7 @@ export function _findRuleMatches(node, path, context) {
       if(
         typeof node[key] === 'object'
       ){
+        console.log('recurse')
         _findRuleMatches(node[key], `${path}.${key}`, context)
       }
     })


### PR DESCRIPTION
Minor update in order to make arbitraryNesting an option within the schema model (default 'true') instead of an implication within the code.

Arbitrary nesting means that datafiles and sidecar metadata files can be found not just within the base /data directory, but any embedded subdirectory thereof.