### PR TITLE
Issue tracing

### DIFF
--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -9,6 +9,7 @@ import { Severity } from '../types/issues.ts'
 import { psychDSContext } from './context.ts'
 import { logger } from '../utils/logger.ts'
 import { memoize } from '../utils/memoize.ts'
+import { psychDSFile } from '../types/file.ts';
   
   /**
    * Given a schema and context, evaluate which rules match and test them.
@@ -132,7 +133,7 @@ import { memoize } from '../utils/memoize.ts'
   function evalColumns(
     _rule: GenericRule,
     context: psychDSContext,
-    _schema: GenericSchema,
+    schema: GenericSchema,
     schemaPath: string,
   ): void {
     if (context.extension !== '.csv') return
@@ -151,20 +152,7 @@ import { memoize } from '../utils/memoize.ts'
             },
           ])
     }
-    
-  }
-  
-  /**
-   * For evaluating field requirements and values that should exist in a json
-   * sidecar for a file. Includes all checks for schema.org validity.
-   *
-   */
-  function evalJsonCheck(
-    rule: GenericRule,
-    context: psychDSContext,
-    schema: GenericSchema,
-    schemaPath: string,
-  ){
+
     //since the inherited structure for issues links them to "files" rather than "instances",
     //we collect each instance of the following issues in a dictionary so that they can be added all at once
     //to the issue corresponding to their file. For instance, if multiple "types" are missing in one metadata file,
@@ -176,6 +164,28 @@ import { memoize } from '../utils/memoize.ts'
       'typeIssues': [] as string[],
       'typeMissingIssues': [] as string[]
     } as SchemaOrgIssues
+    
+    //run full schema.org validity check
+    schemaCheck(
+      context,
+      schema,
+      schemaOrgIssues
+    )
+    
+  }
+  
+  /**
+   * For evaluating field requirements and values that should exist in a json
+   * sidecar for a file. Includes all checks for schema.org validity.
+   *
+   */
+  function evalJsonCheck(
+    rule: GenericRule,
+    context: psychDSContext,
+    _schema: GenericSchema,
+    schemaPath: string,
+  ){
+    
     //issue collection for missing JSON fields as required in schema
     const issueKeys: string[]  = []
     //loop through all the fields found in dataset_metadata.yaml, along with their requirement levels 
@@ -208,12 +218,7 @@ import { memoize } from '../utils/memoize.ts'
         },
       ])
     }
-    //run full schema.org validity check
-    schemaCheck(
-      context,
-      schema,
-      schemaOrgIssues
-    )
+    
   }
 
   //Wrapper function for recursive schema.org validity check. Checks type requirements for root object, 
@@ -230,9 +235,14 @@ import { memoize } from '../utils/memoize.ts'
       //TODO: Check if it's even valid JSON-LD to have more than one values assigned for type
         //if it is valid, it should be accounted for
       if ((context.expandedSidecar['@type'] as string[])[0] !== `${schemaNamespace}Dataset`){
+        let issueFile: psychDSFile
+        if(Object.keys(context.metadataProvenance).includes('@type'))
+          issueFile = context.metadataProvenance['@type']
+        else
+          issueFile = context.file
         context.issues.addNonSchemaIssue('INCORRECT_DATASET_TYPE', [
           {
-            ...context.file,
+            ...issueFile,
             evidence: `dataset_description.json's "@type" property must have "Dataset" as its value.
                       additionally, the term "Dataset" must implicitly or explicitly use the schema.org namespace.
                       The schema.org namespace can be explicitly set using the "@context" key`,
@@ -262,46 +272,94 @@ import { memoize } from '../utils/memoize.ts'
     issues: SchemaOrgIssues
   ){
     if(issues.termIssues.length != 0){
-      context.issues.addNonSchemaIssue('INVALID_SCHEMAORG_PROPERTY', [
-        {
-          ...context.file,
-          evidence: `This file contains one or more keys that use the schema.org namespace, but are not  official schema.org properties.
-                    According to the psych-DS specification, this is not an error, but be advised that these terms will not be
-                    machine-interpretable and do not function as linked data elements. These are the keys in question: [${issues.termIssues}]`,
-        },
-      ])
+      issues.termIssues.forEach((issue) => {
+        const rootKey = issue.split('.')[1]
+        let issueFile: psychDSFile
+        //check to see which metadata file the key with the issue comes from
+        if(Object.keys(context.metadataProvenance).includes(rootKey))
+          issueFile = context.metadataProvenance[rootKey]
+        else
+          issueFile = context.dataset.metadataFile
+
+        context.issues.addNonSchemaIssue('INVALID_SCHEMAORG_PROPERTY', [
+          {
+            ...issueFile,
+            evidence: `This file contains one or more keys that use the schema.org namespace, but are not  official schema.org properties.
+                      According to the psych-DS specification, this is not an error, but be advised that these terms will not be
+                      machine-interpretable and do not function as linked data elements. These are the keys in question: [${issues.termIssues}]`,
+          },
+        ])
+        
+      })
+      
     }
     if(issues.typeIssues.length != 0){
-      context.issues.addNonSchemaIssue('INVALID_OBJECT_TYPE', [
-        {
-          ...context.file,
-          evidence: `This file contains one or more objects with types that do not match the selectional constraints of their keys.
-                     Each schema.org property (which take the form of keys in your metadata json) has a specific range of types
-                     that can be used as its value. Type constraints for a given property can be found by visiting their corresponding schema.org
-                     URL. All properties can take strings or URLS as objects, under the assumption that the string/URL represents a unique ID.
-                     Type selection errors occured at the following locations in your json structure: [${issues.typeIssues}]`,
-        },
-      ])
+      issues.typeIssues.forEach((issue) => {
+        const rootKey = issue.split('.')[1]
+        let issueFile: psychDSFile
+        //check to see which metadata file the key with the issue comes from
+        if(rootKey in context.metadataProvenance)
+          issueFile = context.metadataProvenance[rootKey]
+        else
+          issueFile = context.dataset.metadataFile
+
+        context.issues.addNonSchemaIssue('INVALID_OBJECT_TYPE', [
+          {
+            ...issueFile,
+            evidence: `This file contains one or more objects with types that do not match the selectional constraints of their keys.
+                        Each schema.org property (which take the form of keys in your metadata json) has a specific range of types
+                        that can be used as its value. Type constraints for a given property can be found by visiting their corresponding schema.org
+                        URL. All properties can take strings or URLS as objects, under the assumption that the string/URL represents a unique ID.
+                        Type selection errors occured at the following locations in your json structure: [${issues.typeIssues}]`,
+          },
+        ])
+        
+      })
+      
     }
     if(issues.typeMissingIssues.length != 0){
-      context.issues.addNonSchemaIssue('OBJECT_TYPE_MISSING', [
-        {
-          ...context.file,
-          evidence: `This file contains one or more objects without a @type property. Make sure that any object that you include
-                    as the value of a schema.org property contains a valid schema.org @type, unless it is functioning as some kind of 
-                    base type, such as Text or URL, containing a @value key. @type is optional, but not required on such objects.
-                    The following objects without @type were found: [${issues.typeMissingIssues}]`,
-        },
-      ])
+      issues.typeMissingIssues.forEach((issue) => {
+        const rootKey = issue.split('.')[1]
+        let issueFile: psychDSFile
+        //check to see which metadata file the key with the issue comes from
+        if(Object.keys(context.metadataProvenance).includes(rootKey))
+          issueFile = context.metadataProvenance[rootKey]
+        else
+          issueFile = context.dataset.metadataFile
+
+        context.issues.addNonSchemaIssue('OBJECT_TYPE_MISSING', [
+          {
+            ...issueFile,
+            evidence: `This file contains one or more objects without a @type property. Make sure that any object that you include
+                      as the value of a schema.org property contains a valid schema.org @type, unless it is functioning as some kind of 
+                      base type, such as Text or URL, containing a @value key. @type is optional, but not required on such objects.
+                      The following objects without @type were found: [${issues.typeMissingIssues}]`,
+          },
+        ])
+        
+      })
+      
     }
     if(issues.unknownNamespaceIssues.length != 0){
-      context.issues.addNonSchemaIssue('UNKNOWN_NAMESPACE', [
-        {
-          ...context.file,
-          evidence: `This file contains one or more references to namespaces other than http://schema.org:
-                    [${issues.unknownNamespaceIssues}].`,
-        },
-      ])
+      issues.unknownNamespaceIssues.forEach((issue) => {
+        const rootKey = issue.split('.')[0]
+        let issueFile: psychDSFile
+        //check to see which metadata file the key with the issue comes from
+        if(Object.keys(context.metadataProvenance).includes(rootKey))
+          issueFile = context.metadataProvenance[rootKey]
+        else
+          issueFile = context.dataset.metadataFile
+
+        context.issues.addNonSchemaIssue('UNKNOWN_NAMESPACE', [
+          {
+            ...issueFile,
+            evidence: `This file contains one or more references to namespaces other than http://schema.org:
+                      [${issues.unknownNamespaceIssues}].`,
+          },
+        ])
+        
+      })
+      
     }
   }
 
@@ -363,7 +421,7 @@ import { memoize } from '../utils/memoize.ts'
           let subKeys: string[] = []
           //if current property is not a valid slot of this object type, raise issue
           if (!(superClassSlots.includes(property))){
-            issues.termIssues.push(property)
+            issues.termIssues.push(`${objectPath}.${property}`)
           }
           else{
             //loop through all objects listed as value for this property
@@ -413,8 +471,10 @@ import { memoize } from '../utils/memoize.ts'
     if(type in schema[`schemaOrg.default.classes`]){
       //if type has a super class, append this type's slots to the result of this function for super class
       if('is_a' in schema[`schemaOrg.default.classes.${type}`]){
-        if('slots' in schema[`schemaOrg.default.classes.${type}`])
+        if('slots' in schema[`schemaOrg.default.classes.${type}`]){
           return (schema[`schemaOrg.default.classes.${type}.slots`] as unknown as string[]).concat(getSuperClassSlots(schema[`schemaOrg.default.classes.${type}.is_a`] as unknown as string,schema,nameSpace))
+
+        }
         else
           return getSuperClassSlots(schema[`schemaOrg.default.classes.${type}.is_a`] as unknown as string,schema,nameSpace)
       }
@@ -423,8 +483,7 @@ import { memoize } from '../utils/memoize.ts'
         return schema[`schemaOrg.default.classes.${type}.slots`] as unknown as string[]
 
     }
-    else
-      return []
+    return []
   }
 
   //recursive function for finding all classes that are more specific versions of a given class

--- a/src/schema/context.test.ts
+++ b/src/schema/context.test.ts
@@ -18,7 +18,7 @@ const ddFile = fileTree.files.find(
 let dsContext: psychDSContextDataset = new psychDSContextDataset()
 if (ddFile) {
   const description = await ddFile.text().then((text) => JSON.parse(text))
-  dsContext = new psychDSContextDataset({datasetPath:PATH} as ValidatorOptions, description)
+  dsContext = new psychDSContextDataset({datasetPath:PATH} as ValidatorOptions, ddFile,description)
 }
 
 

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,11 +1,13 @@
 // deno-lint-ignore-file no-explicit-any
 import { ValidatorOptions } from '../setup/options.ts'
+import { psychDSFile } from './file.ts';
 
 export interface ContextDataset {
   dataset_description: Record<string, unknown>
   files: any[]
   tree: object
   ignored: any[]
+  metadataFile: psychDSFile
   options?: ValidatorOptions
 }
 export interface Context {
@@ -19,6 +21,7 @@ export interface Context {
   sidecar: object
   validColumns: object
   suggestedColumns: string[]
+  metadataProvenance: Record<string,psychDSFile>
   json: object
   
 }

--- a/src/validators/psychds.ts
+++ b/src/validators/psychds.ts
@@ -45,10 +45,10 @@ export async function validate(
   if (ddFile) {
     try{
       const description = await ddFile.text().then((text) => JSON.parse(text))
-      dsContext = new psychDSContextDataset(options, description)
+      dsContext = new psychDSContextDataset(options, ddFile,description)
     }
     catch(_error){
-      dsContext = new psychDSContextDataset(options)
+      dsContext = new psychDSContextDataset(options,ddFile)
       issues.addNonSchemaIssue(
         'INVALID_JSON_FORMATTING',
         [ddFile]

--- a/test_data/invalid_datasets/bfi-dataset/data/raw_data/study-bfi_data.json
+++ b/test_data/invalid_datasets/bfi-dataset/data/raw_data/study-bfi_data.json
@@ -1,3 +1,5 @@
 {
-    "key":"value"
+    "author":{
+        "@type":"propertyValue"
+    }
 }

--- a/test_data/invalid_datasets/bfi-dataset/dataset_description.json
+++ b/test_data/invalid_datasets/bfi-dataset/dataset_description.json
@@ -3,7 +3,7 @@
   "identifier": ["https://dx.doi.org/10.17605/OSF.IO/K39BG"],
   "creator": [
     {
-      "@type":["Dataset"],
+      "@type":["Person"],
       "name": "William Revelle"
     }
   ],
@@ -28,7 +28,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"],
+      "@type": ["PropertyValue"],
       "https://linkml/minValue":[2]
     },
     {
@@ -37,7 +37,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["A4"],
@@ -45,7 +45,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["A5"],
@@ -53,7 +53,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["C1"],
@@ -61,7 +61,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["C2"],
@@ -69,7 +69,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["C3"],
@@ -77,7 +77,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["C4R"],
@@ -85,7 +85,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["C5R"],
@@ -93,7 +93,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["E1R"],
@@ -101,7 +101,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["E2R"],
@@ -109,7 +109,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["E3"],
@@ -117,7 +117,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["E4"],
@@ -125,7 +125,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["E5"],
@@ -133,7 +133,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["N1R"],
@@ -141,7 +141,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["N2R"],
@@ -149,7 +149,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["N3R"],
@@ -157,7 +157,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["N4R"],
@@ -165,7 +165,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["N5R"],
@@ -173,7 +173,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["O1"],
@@ -181,7 +181,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["O2R"],
@@ -189,7 +189,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["O3"],
@@ -197,7 +197,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["O4"],
@@ -205,7 +205,7 @@
       "value": ["1. Very Inaccurate,\n2. Moderately Inaccurate,\n3. Slightly Inaccurate,\n4. Slightly Accurate,\n5. Moderately Accurate,\n6. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["O5R"],
@@ -213,7 +213,7 @@
       "value": ["6. Very Inaccurate,\n5. Moderately Inaccurate,\n4. Slightly Inaccurate,\n3. Slightly Accurate,\n2. Moderately Accurate,\n1. Very Accurate"],
       "maxValue": [6],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["gender"],
@@ -221,7 +221,7 @@
       "value": ["1. male,\n2. female"],
       "maxValue": [2],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["education"],
@@ -229,22 +229,22 @@
       "value": ["1. in high school,\n2. finished high school,\n3. some college,\n4. college graduate,\n5. graduate degree"],
       "maxValue": [5],
       "minValue": [1],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["age"],
       "description": ["age"],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["extraversion"],
       "description": ["5 E items aggregated by rowMeans"],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     },
     {
       "name": ["plasticity"],
       "description": ["10  items aggregated by rowMeans"],
-      "@type": ["propertyValue"]
+      "@type": ["PropertyValue"]
     }
   ]
 }

--- a/test_data/valid_datasets/bfi-dataset/dataset_description.json
+++ b/test_data/valid_datasets/bfi-dataset/dataset_description.json
@@ -12,8 +12,7 @@
   "@type": "Dataset",
   "author":{
     "@type":"Person",
-    "name":"yes",
-    "variableMeasured": []
+    "name":"Person"
   },
   "variableMeasured": ["A1","A2","A3","A4","A5","C1","C2","C3","C4","C5","E1","E2","E3","E4","E5","N1","N2","N3","N4","N5","O1","O2","O3","O4","O5","gender","education","age"]
 }


### PR DESCRIPTION
This PR closes issue #31. 

I've added a metadataProvenance object that gets attached to the working context and keeps track of which keys in the metadata arise from which sidecar file. Now, when high-level issues are reported about the metadata, the issue outputs point directly to the actual problem file rather than the default metadata file. 

In the course of this PR, I also uncovered and resolved an error where schema.org rules were being checked upon finding a "dataset_description.json" file in the tree, when really these rules should be checked every time a valid datafile is encountered (because sidecar inheritance makes it so every datafile might have its own unique composite metadata object)