### PR TITLE
Filename fixes

### DIFF
--- a/src/files/ignore.test.ts
+++ b/src/files/ignore.test.ts
@@ -7,7 +7,6 @@ Deno.test('Deno implementation of FileIgnoreRules', async (t) => {
       '/sub-01/anat/sub-01_T1w.nii.gz',
       '/dataset_description.json',
       '/README',
-      '/CHANGES',
       '/participants.tsv',
       '/.git/HEAD',
       '/sub-01/anat/non-bidsy-file.xyz',

--- a/src/files/ignore.ts
+++ b/src/files/ignore.ts
@@ -13,6 +13,7 @@ export async function readPsychDSIgnore(file: psychDSFile) {
 
 const defaultIgnores = [
   '.git**',
+  '*.DS_Store',
   '.datalad/',
   '.reproman/',
   'sourcedata/',
@@ -21,11 +22,9 @@ const defaultIgnores = [
   'materials/',
   'results/',
   'products/',
+  'analysis/',
   'documentation/',
-  'CHANGES*',
-  'log/',
-  '**/meg/*.ds/**',
-  '**/micr/*.zarr/**',
+  'log/'
 ]
 
 /**

--- a/src/schema/applyRules.test.ts
+++ b/src/schema/applyRules.test.ts
@@ -86,7 +86,7 @@ Deno.test({
           dsContext = new psychDSContextDataset({datasetPath:PATH} as ValidatorOptions, ddFile, description)
         }
       
-        const fileName = '/dataset_description.json'
+        const fileName = '/data/raw_data/study-bfi_data.csv'
         const file = new psychDSFileDeno(PATH, fileName, ignore)
         const context = new psychDSContext(fileTree, file, issues,dsContext)
         await context.asyncLoads()
@@ -105,7 +105,7 @@ Deno.test({
         const description = await ddFile.text().then((text: string) => JSON.parse(text))
         dsContext = new psychDSContextDataset({datasetPath:invPATH} as ValidatorOptions, ddFile, description)
       }
-      const fileName = 'dataset_description.json'
+      const fileName = '/data/raw_data/study-bfi_data.csv'
       const file = new psychDSFileDeno(invPATH, fileName, ignore)
       const context = new psychDSContext(invFileTree, file, issues,dsContext)
       await context.asyncLoads()
@@ -123,7 +123,7 @@ Deno.test({
         const description = await ddFile.text().then((text: string) => JSON.parse(text))
         dsContext = new psychDSContextDataset({datasetPath:noCtxPATH} as ValidatorOptions, ddFile, description)
       }
-      const fileName = 'dataset_description.json'
+      const fileName = '/data/raw_data/study-bfi_data.csv'
       const file = new psychDSFileDeno(noCtxPATH, fileName, ignore)
       const context = new psychDSContext(noCtxFileTree, file, issues,dsContext)
       

--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -94,7 +94,7 @@ import { psychDSFile } from '../types/file.ts';
       schemaPath: string,
     ) => boolean | void | Promise<void>
   > = {
-    columns: evalColumns,
+    columnsMatchMetadata: evalColumns,
     fields: evalJsonCheck,
   }
   

--- a/src/setup/loadSchema.ts
+++ b/src/setup/loadSchema.ts
@@ -1,6 +1,6 @@
 import { Schema } from '../types/schema.ts'
 import { objectPathHandler } from '../utils/objectPathHandler.ts'
-import * as schemaDefault from 'https://raw.githubusercontent.com/psych-ds/psych-DS/develop/schema_model/versions/jsons/latest/schema.json' with { type: 'json' }
+import * as schemaDefault from 'https://raw.githubusercontent.com/psych-ds/psych-DS/develop/schema_model/versions/jsons/1.1.0/schema.json' with { type: 'json' }
 
 /**
  * Load the schema from the specification
@@ -12,11 +12,11 @@ export async function loadSchema(version = 'latest'): Promise<Schema> {
   let schemaUrl = version
   const psychdsSchema =
     typeof Deno !== 'undefined' ? Deno.env.get('psychDS_SCHEMA') : undefined
-  const schemaOrgUrl = `https://raw.githubusercontent.com/psych-ds/psych-DS/develop/schema_model/external_schemas/schemaorg/schemaorg.json?v=${Date.now()}`
+  const schemaOrgUrl = `https://raw.githubusercontent.com/psych-ds/psych-DS/develop/schema_model/external_schemas/schemaorg/schemaorg.json?v=34${Date.now()}`
   if (psychdsSchema !== undefined) {
     schemaUrl = psychdsSchema
   } else if (version === 'latest' || versionRegex.test(version)) {
-    schemaUrl = `https://raw.githubusercontent.com/psych-ds/psych-DS/develop/schema_model/versions/jsons/${version}/schema.json?v=${Date.now()}`
+    schemaUrl = `https://raw.githubusercontent.com/psych-ds/psych-DS/develop/schema_model/versions/jsons/${version}/schema.json?v=34${Date.now()}`
   }
   try {
     let schemaModule = await import(schemaUrl, {
@@ -26,10 +26,8 @@ export async function loadSchema(version = 'latest'): Promise<Schema> {
     const schemaOrgModule = await import(schemaOrgUrl, {
       with: { type: 'json'},
     })
-    //console.log(schemaModule)
     schemaModule.default = {...schemaModule.default,
       schemaOrg:schemaOrgModule}
-      //console.log(schemaModule.default)
     return new Proxy(
       schemaModule.default as object,
       objectPathHandler,

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -68,7 +68,7 @@ export interface GenericRuleOrg {
 export interface GenericRule {
   selectors?: string[]
   checks?: string[]
-  columns?: Record<string, string>
+  columnsMatchMetadata?: boolean
   additional_columns?: string
   initial_columns?: string[]
   fields: Record<string, SchemaFields>

--- a/src/validators/filenameIdentify.test.ts
+++ b/src/validators/filenameIdentify.test.ts
@@ -21,6 +21,9 @@ const ignore = new FileIgnoreRules([])
 
 const node = {
   stem: 'dataset_description',
+  arbitraryNesting: true,
+  baseDir: "/",
+  extensions: [".json"]
 }
 
 const recurseNode = {


### PR DESCRIPTION
This PR closes issue #43 and represents the last major chunk of issue #25

I've consolidated the properties used to identify files in _findRuleMatches and factored out the match conditions to their own function, which hopefully makes things clearer and neater. 

- Now all file rules have the arbitraryNesting, baseDir, and extensions properties, along with either the suffix or the stem property. 
- All directory rules have the path and directory properties. 
- Files meant to be located in the root directory now have baseDir value "/" and arbitraryNesting value "false", indicating that they must be found directly within the root directory, with no intervening subdirectories.

Some other minor changes include an update to the name for the property that indicates that a datafile's columns must match the "variableMeasured" property in the metadata. "columns" -> "columnsMatchMetadata"

I also included some miscellaneous updates to the default ignore list that I noticed in the process of development.


**As for the big-picture issue regarding the difficulty syncing up psych-DS and psychds-validator versions during development, I realized that the simple and obvious solution to this is to actually make use of the "versions" that I've built into the schema_model repository. That is, when I make an update to the schema model from this point on, I will always make sure to add it in a new directory within the repo, with an incremented version number such as 1.X.X. With this, I can make sure that all psychds-validator branches point to specific versions of the schema model rather than always grabbing the 'latest' version.**