### PR TITLE
updated csv parser to use standard library

### DIFF
--- a/src/files/csv.test.ts
+++ b/src/files/csv.test.ts
@@ -35,7 +35,7 @@ Deno.test('Test parseCSV', async (t) => {
                 'issues': []
             }
             })
-        assertEquals(result['issues'][0],'NoHeader')
+        assertEquals(result['issues'][0]['issue'],'NoHeader')
     })
     await t.step('Header row mismatch', async() => {
         const file = new psychDSFileDeno("test_data/testfiles", 'headerRowMismatch.csv', ignore)
@@ -49,7 +49,7 @@ Deno.test('Test parseCSV', async (t) => {
                 'issues': []
             }
             })
-        assertEquals(result['issues'][0],'HeaderRowMismatch')
+        assertEquals(result['issues'][0]['issue'],'HeaderRowMismatch')
     })
     await t.step('Row_id values not unique', async() => {
         const file = new psychDSFileDeno("test_data/testfiles", 'rowidValuesNotUnique.csv', ignore)
@@ -63,7 +63,7 @@ Deno.test('Test parseCSV', async (t) => {
                 'issues': []
             }
             })
-        assertEquals(result['issues'][0],'RowidValuesNotUnique')
+        assertEquals(result['issues'][0]['issue'],'RowidValuesNotUnique')
     })
 
   })

--- a/src/files/csv.ts
+++ b/src/files/csv.ts
@@ -2,58 +2,59 @@
  * CSV
  * Module for parsing CSV
  */
+
 import { ColumnsMap } from '../types/columns.ts'
+import { parse } from "jsr:@std/csv";
 
 const normalizeEOL = (str: string): string =>
   str.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-// Typescript resolved `row && !/^\s*$/.test(row)` as `string | boolean`
-const isContentfulRow = (row: string): boolean => !!(row && !/^\s*$/.test(row))
+
+export interface csvIssue {
+  issue: string
+  message: string | null
+}
 
 // gets columns from CSV
 export function parseCSV(contents: string) {
   const columns = new ColumnsMap()
-  const issues: string[] = []
-  const rows: string[][] = normalizeEOL(contents)
-    .split('\n')
-    .filter(isContentfulRow)
-    .map((str) => {
-      //extra logic to confirm that commas used within double quotes are maintained and not considered delimiters
-      const matches = str.match(/".*"/)
-      matches?.forEach((match) => {
-        const newMatch = match.replace(",","[REPLACE]")
-        str = str.replace(match,newMatch)
-      })
-     return str.split(',').map((x)=>x.replace("[REPLACE]",","))
-    })
-  const headers = rows.length ? rows[0] : []
+  const issues: csvIssue[] = []
+  const normalizedStr = normalizeEOL(contents)
+  try{
+    const rows : string[][] = parse(normalizedStr)
+    const headers = rows.length ? rows[0] : []
   
-  //if no header is present, log error
-  if (headers.length === 0)
-    issues.push('NoHeader')
-  else{
-    //if any row in CSV contains different number of cells than the header, log error
-    if(!rows.slice(1).every((row) => row.length === headers.length))
-      issues.push("HeaderRowMismatch")
-  }
-
-  headers.map((x) => {
-    columns[x] = []
-  })
-  for (let i = 1; i < rows.length; i++) {
-    for (let j = 0; j < headers.length; j++) {
-      const col = columns[headers[j]] as string[]
-      col.push(rows[i][j])
+    //if no header is present, log error
+    if (headers.length === 0)
+      issues.push({'issue':'NoHeader','message':null})
+    else{
+      //if any row in CSV contains different number of cells than the header, log error
+      if(!rows.slice(1).every((row) => row.length === headers.length))
+        issues.push({'issue':'HeaderRowMismatch','message':null})
     }
+
+    headers.map((x) => {
+      columns[x] = []
+    })
+    for (let i = 1; i < rows.length; i++) {
+      for (let j = 0; j < headers.length; j++) {
+        const col = columns[headers[j]] as string[]
+        col.push(rows[i][j])
+      }
+    }
+    //if header called "row_id" is present, assert that all cells are unique values
+    if (Object.keys(columns).includes("row_id") && [...new Set(columns["row_id"] as string[])].length !== (columns["row_id"] as string[]).length)
+      issues.push({'issue':'RowidValuesNotUnique','message':null})
   }
-  //if header called "row_id" is present, assert that all cells are unique values
-  if (Object.keys(columns).includes("row_id") && [...new Set(columns["row_id"] as string[])].length !== (columns["row_id"] as string[]).length)
-    issues.push("RowidValuesNotUnique")
+  catch(error){
+    issues.push({'issue':'CSVFormattingError','message':error.message})
+  }
+  
 
   //response has been modified to return columns object as well as issues object, 
   //to account for the fact that multiple types of issues are now possible
   const response = {
     'columns':columns as ColumnsMap,
-    'issues':issues as string[]
+    'issues':issues as csvIssue[]
   }
   return response
 }

--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -7,7 +7,7 @@ import {
   import { ColumnsMap } from '../types/columns.ts'
   import { readElements } from './elements.ts'
   import { DatasetIssues } from '../issues/datasetIssues.ts'
-  import { parseCSV } from '../files/csv.ts'
+  import { parseCSV,csvIssue } from '../files/csv.ts'
   import { ValidatorOptions } from '../setup/options.ts'
   import { logger } from '../utils/logger.ts'
 
@@ -223,17 +223,28 @@ import {
         result = new Map<string, string[]>() as ColumnsMap
       }
       this.columns = result['columns'] as ColumnsMap
-      this.reportCSVIssues(result['issues'] as string[])
+      this.reportCSVIssues(result['issues'] as csvIssue[])
       return
     }
     
     //multiple CSV issues are possible, so these are unpacked from the issue object
-    reportCSVIssues(issues: string[]){
+    reportCSVIssues(issues: csvIssue[]){
       issues.forEach((issue) => {
-        this.issues.addSchemaIssue(
-          issue,
-          [this.file]
-        )
+        if (issue.message){
+          this.issues.addSchemaIssue(
+            issue.issue,
+            [{...this.file,
+              evidence: issue.message as string
+            }]
+          )
+        }
+        else{
+          this.issues.addSchemaIssue(
+            issue.issue,
+            [this.file]
+          )
+        }
+        
       })
     }
     /*


### PR DESCRIPTION
I've changed the parseCSV function to use a standard library rather than the ad hoc parser inherited from the BIDS version. It now catches errors from the library parse function and pipes them into the new "CSV_FORMATTING_ERROR" issue.