### PR TITLE
Refactor file reading and JSON-LD processing

### DIFF
--- a/src/files/ignore.ts
+++ b/src/files/ignore.ts
@@ -1,8 +1,8 @@
 import { psychDSFile } from '../types/file.ts'
 import { ignore, Ignore } from '../deps/ignore.ts'
 
-export function readPsychDSIgnore(file: psychDSFile) {
-  const value = file.fileText
+export async function readPsychDSIgnore(file: psychDSFile) {
+  const value = await file.text()
   if (value) {
     const lines = value.split('\n')
     return lines

--- a/src/schema/applyRules.test.ts
+++ b/src/schema/applyRules.test.ts
@@ -34,12 +34,12 @@ async function setupTest(path: string, fileName: string) {
   
   let dsContext;
   if (ddFile) {
-    const description = ddFile.expanded;
+    const description = await ddFile.text()
+      .then(JSON.parse)
     dsContext = new psychDSContextDataset({datasetPath: path} as ValidatorOptions, ddFile, description);
   }
 
   const file = new psychDSFileDeno(path, fileName, ignore);
-  file.fileText = await file.text();
   
   const context = new psychDSContext(fileTree, file, issues, dsContext);
   await context.asyncLoads();

--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -191,11 +191,10 @@ import { psychDSFile } from '../types/file.ts';
     //loop through all the fields found in dataset_metadata.yaml, along with their requirement levels 
     for (const [key, requirement] of Object.entries(rule.fields)) {
       const severity = getFieldSeverity(requirement, context)
-      //@ts-expect-error: metadata presence assumed
-      const keyName = `${rule.namespace}${key}`
+      const keyName = `https://schema.org/${key}`
       //expandedSidecar represents the metadata object with all contexts added, e.g. the "name" field becomes the "https://schema.org/name" field.
       //we add this schema.org namespace to keyName to account for this.
-      if (severity && severity !== 'ignore' && !(keyName in context.sidecar)) {
+      if (severity && severity !== 'ignore' && !(keyName in context.expandedSidecar)) {
         if (requirement.issue?.code && requirement.issue?.message) {
           context.issues.add({
             key: requirement.issue.code,
@@ -228,13 +227,13 @@ import { psychDSFile } from '../types/file.ts';
     schema: GenericSchema,
     issues: SchemaOrgIssues
   ){
-    const schemaNamespace = 'http://schema.org/'
+    const schemaNamespace = 'https://schema.org/'
     //@type is required in the root object of the metadata file
-    if ("@type" in context.sidecar){
+    if ("@type" in context.expandedSidecar){
       //@type for the root object must be schema.org/Dataset
       //TODO: Check if it's even valid JSON-LD to have more than one values assigned for type
         //if it is valid, it should be accounted for
-      if ((context.sidecar['@type'] as string[])[0] !== `${schemaNamespace}Dataset`){
+      if ((context.expandedSidecar['@type'] as string[])[0] !== `${schemaNamespace}Dataset`){
         let issueFile: psychDSFile
         if(Object.keys(context.metadataProvenance).includes('@type'))
           issueFile = context.metadataProvenance['@type']
@@ -261,7 +260,7 @@ import { psychDSFile } from '../types/file.ts';
       return
     }
     //collect issues recursively for all keys and values in root object
-    issues = _schemaCheck(context.sidecar, context, schema, '',schemaNamespace,issues)
+    issues = _schemaCheck(context.expandedSidecar, context, schema, '',schemaNamespace,issues)
     logSchemaIssues(context,issues)
   }
 

--- a/src/schema/context.test.ts
+++ b/src/schema/context.test.ts
@@ -23,7 +23,8 @@ Deno.test({
     )
     let dsContext: psychDSContextDataset = new psychDSContextDataset()
     if (ddFile) {
-      const description = ddFile.expanded
+      const description = await ddFile.text()
+        .then(JSON.parse)
       dsContext = new psychDSContextDataset({datasetPath:PATH} as ValidatorOptions, ddFile,description)
     }
     await t.step('file sidecar overwrites directory sidecar', async() => {
@@ -34,8 +35,8 @@ Deno.test({
       const context = new psychDSContext(fileTree, file, issues,dsContext)
       
       await context.loadSidecar(fileTree)
-      if("http://schema.org/key" in context.sidecar){
-        assertEquals(context.sidecar['http://schema.org/key'],[{"@value":"value"}])}
+      if("https://schema.org/key" in context.expandedSidecar){
+        assertEquals(context.expandedSidecar['https://schema.org/key'],[{"@value":"value"}])}
       else
         assertEquals(1,2)
     })
@@ -47,8 +48,8 @@ Deno.test({
       const context = new psychDSContext(fileTree, file, issues,dsContext)
       
       await context.loadSidecar(fileTree)
-      if("http://schema.org/key" in context.sidecar)
-        assertEquals(context.sidecar['http://schema.org/key'],[{"@value":"value2"}])
+      if("https://schema.org/key" in context.expandedSidecar)
+        assertEquals(context.expandedSidecar['https://schema.org/key'],[{"@value":"value2"}])
       else
         assertEquals(1,2)
     })
@@ -60,7 +61,7 @@ Deno.test({
       const context = new psychDSContext(fileTree, file, issues,dsContext)
       
       await context.loadSidecar(fileTree)
-      assertEquals("http://schema.org/name" in context.sidecar,true)
+      assertEquals("https://schema.org/name" in context.expandedSidecar,true)
     })
 
     await t.step('no context in sidecar', async() => {
@@ -78,10 +79,10 @@ Deno.test({
       }
 
       const context = new psychDSContext(noCtxFileTree, file, issues,dsContext)
-      if("@context" in context.sidecar)
-        delete context.sidecar['@context']
+      if("@context" in context.expandedSidecar)
+        delete context.expandedSidecar['@context']
       
       await context.loadSidecar(noCtxFileTree)
-      assertEquals("http://schema.org/name" in context.sidecar,false)
+      assertEquals("https://schema.org/name" in context.expandedSidecar,false)
     })
 }})

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -22,6 +22,5 @@ export interface Context {
   validColumns: object
   suggestedColumns: string[]
   metadataProvenance: Record<string,psychDSFile>
-  json: object
   
 }

--- a/src/types/file.ts
+++ b/src/types/file.ts
@@ -17,8 +17,6 @@ export interface psychDSFile {
     ignored: boolean
     // ReadableStream to file raw contents
     stream: ReadableStream<Uint8Array>
-    // string storage of file contents
-    fileText: string
     // object for temporarily storing issues with jsonld before issue object is created in validate()
     issueInfo: issueInfo[]
     // slot to hold expanded version of jsonld

--- a/src/validators/psychds.ts
+++ b/src/validators/psychds.ts
@@ -48,7 +48,8 @@ export async function validate(
   let dsContext
   if (ddFile) {
     try{
-      const description = ddFile.expanded
+      const description = await ddFile.text()
+        .then(JSON.parse)
       dsContext = new psychDSContextDataset(options, ddFile,description)
     }
     catch(_error){


### PR DESCRIPTION
This PR implements a significant refactoring of our file reading process and JSON-LD handling, aimed at undoing sloppy fixes made previously to accommodate the browser version. The changes include:

1. Simplify file reading in deno.ts:
   - Remove fileText property and JSON-LD parsing from psychDSFileDeno class
   - Simplify _readFileTree function by removing JSON-LD expansion and context handling
   - Move JSON-LD expansion to a more appropriate location

2. Update core files to support new structure:
   - Adjust applyRules.ts to work with the new file reading process
   - Move JSON-LD expansion to getExpandedSidecar method in context.ts
   - Update psychds.ts to handle JSON-LD processing changes and error handling

3. Update type definitions:
   - Remove fileText property from psychDSFile interface
   - Add expanded property to psychDSFile for storing expanded JSON-LD
   - Update Context interface to include validColumns and suggestedColumns
   - Add metadataProvenance to Context for tracking metadata sources

4. Update tests to align with new structure:
   - Refactor applyRules.test.ts to use a setupTest helper function
   - Update test cases to work with the new file reading and JSON-LD processing flow
   - Adjust context.test.ts to handle the new psychDSContext structure
   - Update assertions to check for expanded JSON-LD properties