### PR TITLE
Doomlab syntax errors

### DIFF
--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -415,7 +415,7 @@ import { psychDSFile } from '../types/file.ts';
           //TODO: add else statement? if property is not a valid schema.org slot at all
           let subKeys: string[] = []
           //if current property is not a valid slot of this object type, raise issue
-          if (!(superClassSlots.includes(property))){
+          if (!superClassSlots.includes(property)){
             issues.termIssues.push(`${objectPath}.${property}`)
           }
           else{
@@ -460,25 +460,17 @@ import { psychDSFile } from '../types/file.ts';
     nameSpace: string
   ): string[]{
     
-    if(type.includes(nameSpace)){
-      type = type.replace(nameSpace,"")
-    }
-    if(type in schema[`schemaOrg.classes`]){
-      //if type has a super class, append this type's slots to the result of this function for super class
-      if('is_a' in schema[`schemaOrg.classes.${type}`]){
-        if('slots' in schema[`schemaOrg.classes.${type}`]){
-          return (schema[`schemaOrg.classes.${type}.slots`] as unknown as string[]).concat(getSuperClassSlots(schema[`schemaOrg.classes.${type}.is_a`] as unknown as string,schema,nameSpace))
+    type = type.replace(nameSpace,"")
 
-        }
-        else
-          return getSuperClassSlots(schema[`schemaOrg.classes.${type}.is_a`] as unknown as string,schema,nameSpace)
-      }
-      //TODO: shouldn't another if statement to check for slots presence be needed here?
-      else
-        return schema[`schemaOrg.classes.${type}.slots`] as unknown as string[]
-
+    if (!(type in schema['schemaOrg.classes'])) {
+      return []
     }
-    return []
+
+    //if type has a super class, append this type's slots to the result of this function for super class
+    const slots = schema[`schemaOrg.classes.${type}.slots`] as string[] || []
+    const is_a = 'is_a' in schema[`schemaOrg.classes.${type}`] ? getSuperClassSlots(schema[`schemaOrg.classes.${type}.is_a`] as string, schema, nameSpace) : []
+
+    return [...slots, ...is_a];
   }
 
   //recursive function for finding all classes that are more specific versions of a given class

--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -345,10 +345,19 @@ import {
         //in addition to adding the appropriate namespace (e.g. http://schema.org)
         //to all keys within the json, it also throws a variety of errors for improper JSON-LD syntax,
         //which mostly all pertain to improper usages of privileged @____ keywords
-        if ('@context' in this.sidecar && typeof this.sidecar['@context'] == 'string' && ['http://schema.org/','http://schema.org','http://www.schema.org/','http://www.schema.org','https://schema.org/','https://schema.org','https://www.schema.org/','https://www.schema.org/'].includes(this.sidecar['@context']))
-        this.sidecar['@context'] = {
-          '@vocab':'http://schema.org/'
+        if ('@context' in this.sidecar){
+          
+          if (Array.isArray(this.sidecar['@context']) && this.sidecar['@context'].length === 1){
+            this.sidecar['@context'] = this.sidecar['@context'][0]
+          }
+
+          if (typeof this.sidecar['@context'] == 'string' && ['http://schema.org/','http://schema.org','http://www.schema.org/','http://www.schema.org','https://schema.org/','https://schema.org','https://www.schema.org/','https://www.schema.org/'].includes(this.sidecar['@context'])){
+            this.sidecar['@context'] = {
+              '@vocab':'http://schema.org/'
+            }
+          }
         }
+
         const exp = await jsonldToUse.expand(this.sidecar,expandOptions)
         return exp[0] || {};
       }


### PR DESCRIPTION
#Summary

Closes #80

We ran across some errors when validating Doom Lab's Data Dictionary output.  In response to these errors, I created this PR to support two changes:

1. `@Context` can be a singleton array. 
2. Support schema without `is_a` or `slots`.

