### PR TITLE
Add check for duplicated columns names

### DIFF
--- a/src/files/csv.test.ts
+++ b/src/files/csv.test.ts
@@ -72,4 +72,22 @@ Deno.test("Test parseCSV", async (t) => {
       });
     assertEquals(result["issues"][0]["issue"], "RowidValuesNotUnique");
   });
+  await t.step("Duplicate header names", async ()=>{
+    const file = new psychDSFileDeno(
+      "test_data/testfiles",
+      "duplicateHeaders.csv",
+      ignore,
+    );
+    const result = await file
+    .text()
+    .then((text) => parseCSV(text))
+    .catch((_error) => {
+      return {
+        "columns": new Map<string, string[]>() as ColumnsMap,
+        "issues": [],
+      };
+    });
+    assertEquals(result["issues"][0]["issue"], "CSVHeaderRepeated");
+  })
 });
+

--- a/src/files/csv.ts
+++ b/src/files/csv.ts
@@ -63,6 +63,11 @@ export async function parseCSV(contents: string) {
 
     const headers = rows.length ? rows[0] : [];
 
+    // Check for duplicate headers
+    if (new Set(headers).size !== headers.length) {
+      issues.push({ "issue": "CSVHeaderRepeated", "message": null });
+    }
+
     // Check for missing headers
     if (headers.length === 0) {
       issues.push({ "issue": "CSVHeaderMissing", "message": null });

--- a/src/utils/validationProgressTracker.ts
+++ b/src/utils/validationProgressTracker.ts
@@ -201,6 +201,13 @@ export class ValidationProgressTracker {
             },
           },
           {
+            key: "csv-header-repeat",
+            message: {
+              imperative: `Check for redundant column names`,
+              pastTense: `No redundant column names found`,
+            },
+          },
+          {
             key: "csv-nomismatch",
             message: {
               imperative: `Check all lines for equal number of cells`,

--- a/src/validators/psychds.ts
+++ b/src/validators/psychds.ts
@@ -213,6 +213,7 @@ export async function validate(
   ]);
   emitCheck("csv-parse", ["CSV_FORMATTING_ERROR"]);
   emitCheck("csv-header", ["CSV_HEADER_MISSING"]);
+  emitCheck("csv-header-repeat",["CSV_HEADER_REPEATED"])
   emitCheck("csv-nomismatch", ["CSV_HEADER_LENGTH_MISMATCH"]);
   emitCheck("csv-rowid", ["ROWID_VALUES_NOT_UNIQUE"]);
   emitCheck("check-variableMeasured", ["CSV_COLUMN_MISSING_FROM_METADATA"]);

--- a/test_data/testfiles/duplicateHeaders.csv
+++ b/test_data/testfiles/duplicateHeaders.csv
@@ -1,0 +1,2 @@
+﻿One,Two,Two,Four
+data 1,data 2,data 3,data 4


### PR DESCRIPTION
# Summary

Using the new error in Psych-DS v1.4.2, there's now a check for duplicate column names. 

Issue https://github.com/psych-ds/psych-DS/issues/46