### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,.codespellrc
+skip = .git*,.codespellrc,test_data,defaultSchemaOrg*.json
 check-hidden = true
-# ignore-regex = 
+ignore-regex = \btoLen\b
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/bundled/psychds-validator.js
+++ b/bundled/psychds-validator.js
@@ -2022,7 +2022,7 @@ function logSchemaIssues(context, issues) {
                         Each schema.org property (which take the form of keys in your metadata json) has a specific range of types
                         that can be used as its value. Type constraints for a given property can be found by visiting their corresponding schema.org
                         URL. All properties can take strings or URLS as objects, under the assumption that the string/URL represents a unique ID.
-                        Type selection errors occured at the following locations in your json structure: [${issues.typeIssues}]`
+                        Type selection errors occurred at the following locations in your json structure: [${issues.typeIssues}]`
                 }
             ]);
         });

--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -360,7 +360,7 @@ function logSchemaIssues(
                         Each schema.org property (which take the form of keys in your metadata json) has a specific range of types
                         that can be used as its value. Type constraints for a given property can be found by visiting their corresponding schema.org
                         URL. All properties can take strings or URLS as objects, under the assumption that the string/URL represents a unique ID.
-                        Type selection errors occured at the following locations in your json structure: [${issues.typeIssues}]`,
+                        Type selection errors occurred at the following locations in your json structure: [${issues.typeIssues}]`,
         },
       ]);
     });


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

feel free to ignore