### PR TITLE
bug: removed conditional for ending process early

### DIFF
--- a/src/validators/psychds.ts
+++ b/src/validators/psychds.ts
@@ -79,13 +79,6 @@ export async function validate(
         success: false,
         issue: issues.get("INVALID_JSON_FORMATTING"),
       });
-      if (options.emitter) {
-        return {
-          valid: false,
-          issues,
-          summary: summary.formatOutput(),
-        };
-      }
     }
   } else {
     // Handle missing dataset description


### PR DESCRIPTION
Closes #39 

There was a conditional leftover from when I was developing the checklist mode for the validator, which was ending the process manually instead of just emitting the failure event and letting the validationProgressTracker end the process itself. Now the correct error appears when the JSON is improperly formatted.

